### PR TITLE
[Blog] Update hyperlink references for 3rd parties

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,10 +29,13 @@ description: >- # used by seo meta and the atom feed
 url: "https://www.seg.dev/"
 
 github:
-  username: github_username # change to your github username
+  username: segrowth
 
 twitter:
-  username: twitter_username # change to your twitter username
+  username: S_E_Growth
+
+youtube:
+  username: Software-Engineering-Growth
 
 social:
   # Change to your full name.

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -6,13 +6,16 @@
 - type: twitter
   icon: "fab fa-twitter"
 
+- type: youtube
+  icon: "fab fa-youtube"
+
 - type: email
   icon: "fas fa-envelope"
   noblank: true # open link in current tab
 
-- type: rss
-  icon: "fas fa-rss"
-  noblank: true
+# - type: rss
+#   icon: "fas fa-rss"
+#   noblank: true
 # Uncomment and complete the url below to enable more contact options
 #
 # - type: mastodon

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -13,9 +13,9 @@
   icon: "fas fa-envelope"
   noblank: true # open link in current tab
 
-# - type: rss
-#   icon: "fas fa-rss"
-#   noblank: true
+- type: rss
+  icon: "fas fa-rss"
+  noblank: true
 # Uncomment and complete the url below to enable more contact options
 #
 # - type: mastodon

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -60,6 +60,10 @@
           {%- capture url -%}
             https://{{ entry.type }}.com/{{ site[entry.type].username }}
           {%- endcapture -%}
+        {% when 'youtube' %}
+          {%- capture url -%}
+            https://{{ entry.type }}.com/@{{ site[entry.type].username }}
+          {%- endcapture -%}
         {% when 'email' %}
           {% assign email = site.social.email | split: '@' %}
           {%- capture url -%}


### PR DESCRIPTION
Trello item: [Update hyperlink references for 3rd parties on blog pages](https://trello.com/c/7B8EwE0s/88-update-hyperlink-references-for-3rd-parties-on-blog-pages)

This commit:
- updates GitHub and Twitter usernames, adds YouTube username in the config
- adds YouTube contact and sidebar option
- disables unused RSS feed in the config

After checking, I see the e-mail reference works fine already - in my case, it opens Outlook with the correct e-mail address:

![admin_seg_dev_email](https://github.com/user-attachments/assets/6f205482-157d-459f-9cf8-4e1a1d2eb76e)

Currently the side bar looks as follows:

![seg_sidebar_updated](https://github.com/user-attachments/assets/b375fe28-2ae6-448d-951f-68ccf733b99e)


