### PR TITLE
[ANALYTICS] Add google analytics and enable pwa

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ google_site_verification: # fill in to your verification string
 # The end of `jekyll-seo-tag` settings
 
 google_analytics:
-  id: # fill in your Google Analytics ID
+  id: G-JHQW7FZXYV
 
 # Prefer color scheme setting.
 #
@@ -113,7 +113,7 @@ assets:
     env: # [development|production]
 
 pwa:
-  enabled: false # the option for PWA feature
+  enabled: true # the option for PWA feature
 
 paginate: 10
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -60,7 +60,7 @@
   {% endif %}
 
   <!-- GA -->
-  {% if jekyll.environment == 'production' and site.google_analytics.id != empty and site.google_analytics.id %}
+  {% if site.google_analytics.id != empty and site.google_analytics.id %}
     <link rel="preconnect" href="https://www.google-analytics.com" crossorigin="use-credentials">
     <link rel="dns-prefetch" href="https://www.google-analytics.com">
 

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -91,7 +91,7 @@
   <script id="MathJax-script" async src="{{ site.data.origin[type].mathjax.js | relative_url }}"></script>
 {% endif %}
 
-{% if jekyll.environment == 'production' %}
+{% if site.google_analytics.id != empty and site.google_analytics.id %}
   <!-- PWA -->
   {% if site.pwa.enabled %}
     <script defer src="{{ '/app.js' | relative_url }}"></script>


### PR DESCRIPTION
The google analytics was provided under 'production' configuration removed that dependency.

Why enabling pwa?

Offline Support: It allows users to access your website even when they are offline or have a poor network connection by caching key assets. This makes the site more reliable and accessible at all times.

App-like Experience: The PWA plugin adds features like a service worker, manifest, and caching strategies, enabling the website to behave more like a native app (e.g., with faster load times and offline capabilities).

Improved Performance: PWAs are known for their fast load speeds, and the plugin helps optimize resources like CSS, JS, and images, leading to a smoother user experience.

Push Notifications: If configured, it can enable push notifications, keeping users engaged with updates or new content.

Installable: It allows users to install the website as an app on their device, adding a home screen icon, giving it a native app feel.

SEO and Lighthouse Scores: Since PWAs improve site speed and user experience, they can indirectly boost SEO performance and improve scores on tools like Google Lighthouse.

Confirmation that the google analytics shows up.
<img width="1203" alt="Screenshot 2024-10-01 at 8 47 54 AM" src="https://github.com/user-attachments/assets/38aadd79-300e-4df5-847c-1f0355b0ef79">
